### PR TITLE
chore: replace Renovate with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 14
+      semver-major-days: 28

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["github>fdebijl/renovate"]
-}


### PR DESCRIPTION
Renovate's access to this account/org has been revoked, so this repo moves to Dependabot for dependency updates.

- Removes `renovate.json`
- Adds `.github/dependabot.yml` covering: **github-actions, npm**

Defaults follow the config in `fdebijl/warthunder.cheap`: weekly schedule, 5 open PRs per ecosystem, `rebase-strategy: auto`, and cooldowns (7d for actions, 14d minor / 28d major elsewhere).
